### PR TITLE
Track latest Bevy main

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub fn get_render_graph(app: &mut App) -> String {
         .unwrap_or_else(|_| panic!("no render app"));
     let render_graph = render_app.world.get_resource::<RenderGraph>().unwrap();
 
-    render_graph::render_graph_dot(&*render_graph)
+    render_graph::render_graph_dot(render_graph)
 }
 
 /// Prints the system schedule of the render sub-app.


### PR DESCRIPTION
Hi, great plugin.
I wanted to use this on Bevy main (and PRs towards it) so I crossed my fingers that your plugin would be easy to update.

Luckily it was.
Main difference is that `SystemContainer` is now a struct and not a trait.
Added some bonus clippy fixes.


Cargo.toml to be updated when Bevy 0.9 is tagged.
These changes are currently building correctly towards Bevy cb5e2d84b.
I'll also make a more proper changelog in the commit msg then.


So: I'll keep this PR open and update it asap when 0.9 arrives,
let me know if you don't want it or want something changed etc.

