### PR TITLE
Add configurable colored systems

### DIFF
--- a/src/schedule_graph/mod.rs
+++ b/src/schedule_graph/mod.rs
@@ -133,6 +133,7 @@ pub fn schedule_graph_dot(schedule: &Schedule, world: &World, settings: &Setting
             ("rankdir", settings.style.schedule_rankdir.as_dot()),
             ("bgcolor", &settings.style.color_background),
             ("fontname", &settings.style.fontname),
+            ("nodesep", "0.15"),
         ],
     )
     .edge_attributes(&[("penwidth", &format!("{}", settings.style.penwidth_edge))])

--- a/src/schedule_graph/mod.rs
+++ b/src/schedule_graph/mod.rs
@@ -1,4 +1,5 @@
 pub mod settings;
+mod system_style;
 
 use bevy_utils::{HashMap, HashSet};
 pub use settings::Settings;
@@ -137,12 +138,7 @@ pub fn schedule_graph_dot(schedule: &Schedule, world: &World, settings: &Setting
         ],
     )
     .edge_attributes(&[("penwidth", &format!("{}", settings.style.penwidth_edge))])
-    .node_attributes(&[
-        ("shape", "box"),
-        ("style", "filled"),
-        ("fillcolor", &settings.style.color_system),
-        ("color", &settings.style.color_system_border),
-    ]);
+    .node_attributes(&[("shape", "box"), ("style", "filled")]);
 
     let context = ScheduleGraphContext {
         settings,
@@ -396,11 +392,22 @@ impl ScheduleGraphContext<'_> {
             .get(&set_id)
             .map(|systems| systems.as_slice())
             .unwrap_or(&[]);
+
         for &(system_id, system) in systems.iter() {
             let name = self.system_name(system);
+            let node_style = self.settings.get_system_style(system);
+
             system_set_graph.add_node(
                 &self.node_ref(system_id),
-                &[("label", &name), ("tooltip", &system.name())],
+                &[
+                    ("label", &name),
+                    ("tooltip", &system.name()),
+                    ("fillcolor", &node_style.bg_color),
+                    ("fontname", &self.settings.style.fontname),
+                    ("fontcolor", &node_style.text_color),
+                    ("color", &node_style.border_color),
+                    ("penwidth", &node_style.border_width.to_string()),
+                ],
             );
         }
 

--- a/src/schedule_graph/mod.rs
+++ b/src/schedule_graph/mod.rs
@@ -361,10 +361,12 @@ impl ScheduleGraphContext<'_> {
         let mut system_set_graph = DotGraph::subgraph(
             &system_set_cluster_name,
             &[
+                ("style", "rounded,filled"),
                 ("label", &name),
                 ("tooltip", &name),
-                ("bgcolor", &self.settings.style.color_set),
+                ("fillcolor", &self.settings.style.color_set),
                 ("color", &self.settings.style.color_set_border),
+                ("penwidth", "2"),
             ],
         );
 

--- a/src/schedule_graph/settings.rs
+++ b/src/schedule_graph/settings.rs
@@ -70,8 +70,8 @@ impl Style {
             color_background: "white".into(),
             color_system: "white".into(),
             color_system_border: "black".into(),
-            color_set: "white".into(),
-            color_set_border: "black".into(),
+            color_set: "#00000005".into(),
+            color_set_border: "#00000040".into(),
             color_edge: vec![
                 "#eede00".into(),
                 "#881877".into(),
@@ -100,8 +100,8 @@ impl Style {
             color_background: "#35393f".into(),
             color_system: "#eff1f3".into(),
             color_system_border: "#eff1f3".into(),
-            color_set: "#99aab5".into(),
-            color_set_border: "black".into(),
+            color_set: "#ffffff44".into(),
+            color_set_border: "#ffffff50".into(),
             color_edge: vec![
                 "#eede00".into(),
                 "#881877".into(),
@@ -130,8 +130,8 @@ impl Style {
             color_background: "#0d1117".into(),
             color_system: "#eff1f3".into(),
             color_system_border: "#eff1f3".into(),
-            color_set: "#6f90ad".into(),
-            color_set_border: "black".into(),
+            color_set: "#ffffff44".into(),
+            color_set_border: "#ffffff50".into(),
             color_edge: vec![
                 "#eede00".into(),
                 "#881877".into(),


### PR DESCRIPTION
- Add `Settings.system_style` option, which allows to pass a `System => Style` mapper to decide how style single system node.
- If `None` is given (default behaviour) a predefined set of colors are applied

Fixes #13 

### Examples

TODO: Light

TODO: Dark

### Current color palette

![image](https://user-images.githubusercontent.com/188612/222806915-5d1b0214-b7e3-44b9-b6f0-9b474e5c604a.png)
