### PR TITLE
Add a command line arguments plugin.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,18 +84,35 @@ pub fn print_render_graph(app: &mut App) {
     println!("{dot}");
 }
 
-/// Check the command line for arguments.
+/// Check the command line for arguments relevant to this crate. The app will
+/// run as before.
 ///
 /// # Dump the render graph
 ///
 /// Use `--dump-render <file.dot>` to dump the render graph.
-///
 ///
 /// # Dump the schedule graph
 ///
 /// Use `--dump-schedule <file.dot>` to dump the `Update` schedule graph.
 ///
 /// Does not require disabling of logging.
+///
+/// ```rust,no_run
+/// use bevy::prelude::*;
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         // Include all other setup as normal.
+///         .add_plugins(bevy_mod_debugdump::CommandLineArgs)
+///         .run();
+/// }
+/// ```
+///
+/// # Exit the app
+///
+/// Use `--exit` to exit the app. This may be useful if one wants to create
+/// these graphs in script.
 ///
 /// TODO: Consider adding a means of selecting a schedule other than `Update`.
 pub struct CommandLineArgs;
@@ -121,6 +138,13 @@ impl bevy_app::Plugin for CommandLineArgs {
                     schedule_graph_dot(app, bevy_app::Update, &settings)
                 )
                 .expect("write file");
+            } else if arg == "--exit" {
+                use bevy_ecs::event::EventWriter;
+                // TODO: It would be nice if we could exit before the window
+                // opens, but I don't see how.
+                app.add_systems(bevy_app::First, |mut app_exit_events: EventWriter<bevy_app::AppExit>| {
+                    app_exit_events.send(bevy_app::AppExit);
+                });
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,3 +83,45 @@ pub fn print_render_graph(app: &mut App) {
     let dot = render_graph_dot(app, &render_graph::Settings::default());
     println!("{dot}");
 }
+
+/// Check the command line for arguments.
+///
+/// # Dump the render graph
+///
+/// Use `--dump-render <file.dot>` to dump the render graph.
+///
+///
+/// # Dump the schedule graph
+///
+/// Use `--dump-schedule <file.dot>` to dump the `Update` schedule graph.
+///
+/// Does not require disabling of logging.
+///
+/// TODO: Consider adding a means of selecting a schedule other than `Update`.
+pub struct CommandLineArgs;
+
+impl bevy_app::Plugin for CommandLineArgs {
+    fn build(&self, app: &mut App) {
+        use std::fs::File;
+        use std::io::Write;
+        let mut args = std::env::args();
+        while let Some(arg) = args.next() {
+            if arg == "--dump-render" {
+                let settings = render_graph::Settings::default();
+                let mut out =
+                    File::create(args.next().expect("file argument")).expect("file create");
+                write!(out, "{}", render_graph_dot(app, &settings)).expect("write file");
+            } else if arg == "--dump-schedule" {
+                let settings = schedule_graph::Settings::default();
+                let mut out =
+                    File::create(args.next().expect("file argument")).expect("file create");
+                write!(
+                    out,
+                    "{}",
+                    schedule_graph_dot(app, bevy_app::Update, &settings)
+                )
+                .expect("write file");
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,18 +84,25 @@ pub fn print_render_graph(app: &mut App) {
     println!("{dot}");
 }
 
-/// Check the command line for arguments relevant to this crate. The app will
-/// run as before.
+/// Check the command line for arguments relevant to this crate.
 ///
-/// # Dump the render graph
+/// ## Dump the render graph
 ///
 /// Use `--dump-render <file.dot>` to dump the render graph.
 ///
-/// # Dump the schedule graph
+/// ## Dump the schedule graph
 ///
 /// Use `--dump-schedule <file.dot>` to dump the `Update` schedule graph.
 ///
-/// Does not require disabling of logging.
+/// ## Exit the app
+///
+/// Use `--exit` to exit the app. This may be useful if one wants to create
+/// these graphs in script.
+///
+/// # Usage
+///
+/// Set up your app as usual. No log disabling required. Add the
+/// `bevy_mod_debugdump::CommandLineArgs` plugin at the end. And run your app.
 ///
 /// ```rust,no_run
 /// use bevy::prelude::*;
@@ -108,11 +115,6 @@ pub fn print_render_graph(app: &mut App) {
 ///         .run();
 /// }
 /// ```
-///
-/// # Exit the app
-///
-/// Use `--exit` to exit the app. This may be useful if one wants to create
-/// these graphs in script.
 ///
 /// TODO: Consider adding a means of selecting a schedule other than `Update`.
 pub struct CommandLineArgs;
@@ -142,9 +144,12 @@ impl bevy_app::Plugin for CommandLineArgs {
                 use bevy_ecs::event::EventWriter;
                 // TODO: It would be nice if we could exit before the window
                 // opens, but I don't see how.
-                app.add_systems(bevy_app::First, |mut app_exit_events: EventWriter<bevy_app::AppExit>| {
-                    app_exit_events.send(bevy_app::AppExit);
-                });
+                app.add_systems(
+                    bevy_app::First,
+                    |mut app_exit_events: EventWriter<bevy_app::AppExit>| {
+                        app_exit_events.send(bevy_app::AppExit);
+                    },
+                );
             }
         }
     }


### PR DESCRIPTION
Thank you kindly for bevy_mod_debugdump. It's been extremely helpful. I wanted to be able to use it more freely just with some command line arguments ideally and without disrupting `main()` to run or not run the app.  So that's what I added. Here is the document for the `CommandLineArgs` plugin:

Check the command line for arguments relevant to this crate.              
                                                                          
## Dump the render graph                                                  
                                                                          
Use `--dump-render <file.dot>` to dump the render graph.                  
                                                                          
## Dump the schedule graph                                                
                                                                          
Use `--dump-schedule <file.dot>` to dump the `Update` schedule graph.     
                                                                          
## Exit the app                                                           
                                                                          
Use `--exit` to exit the app. This may be useful if one wants to create   
these graphs in script.                                                   
                                                                          
# Usage                                                                   
                                                                          
Set up your app as usual. No log disabling required. Add the              
`bevy_mod_debugdump::CommandLineArgs` plugin at the end. And run your app.
                                                                          
```rust,no_run                                                            
use bevy::prelude::*;                                                     
                                                                          
fn main() {                                                               
    App::new()                                                            
        .add_plugins(DefaultPlugins)                                      
        // Include all other setup as normal.                             
        .add_plugins(bevy_mod_debugdump::CommandLineArgs)                 
        .run();                                                           
}                                                                         
```                                                                       
                                                                          
TODO: Consider adding a means of selecting a schedule other than `Update`.