### PR TITLE
Update to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,24 +15,25 @@ default = ["render_graph"]
 render_graph = []
 
 [dependencies]
-bevy_ecs = { version = "0.13" }
-bevy_app = { version = "0.13" }
-bevy_utils = { version = "0.13" }
-bevy_render = { version = "0.13" }
+bevy_ecs = { version = "0.14.0-rc.3" }
+bevy_app = { version = "0.14.0-rc.3" }
+bevy_utils = { version = "0.14.0-rc.3" }
+bevy_render = { version = "0.14.0-rc.3" }
+bevy_color = { version = "0.14.0-rc.3" }
 pretty-type-name = "1.0"
 petgraph = "0.6"
 once_cell = "1.17"
 
 [dev-dependencies]
-bevy = { version = "0.13" }
+bevy = { version = "0.14.0-rc.3" }
 
 [[example]]
 name = "print_render_graph"
 required-features = ["render_graph"]
 
 # [patch.crates-io]
-# bevy_ecs = { path = "/home/jakob/dev/rust/bevy/crates/bevy_ecs" }
-# bevy_app = { path = "/home/jakob/dev/rust/bevy/crates/bevy_app" }
-# bevy_utils = { path = "/home/jakob/dev/rust/bevy/crates/bevy_utils" }
-# bevy_render = { path = "/home/jakob/dev/rust/bevy/crates/bevy_render" }
-# bevy = { path = "/home/jakob/dev/rust/bevy" }
+# bevy_ecs = { path = "../bevy/crates/bevy_ecs" }
+# bevy_app = { path = "../bevy/crates/bevy_app" }
+# bevy_utils = { path = "../bevy/crates/bevy_utils" }
+# bevy_render = { path = "../bevy/crates/bevy_render" }
+# bevy = { path = "../bevy" }

--- a/examples/schedule_graph_compare.rs
+++ b/examples/schedule_graph_compare.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins);
 
-    app.world
+    app.world_mut()
         .resource_scope::<Schedules, _>(|world, mut schedules| {
             let ignored_ambiguities = schedules.ignored_scheduling_ambiguities.clone();
 

--- a/examples/schedule_graph_testing.rs
+++ b/examples/schedule_graph_testing.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), std::io::Error> {
     // app.configure_sets((TestSet::A, TestSet::B).chain().in_set(TestSet::C));
     app.add_plugins(DefaultPlugins.build().disable::<bevy::log::LogPlugin>());
 
-    app.world
+    app.world_mut()
         .resource_scope::<Schedules, _>(|world, mut schedules| {
             let ignored_ambiguities = schedules.ignored_scheduling_ambiguities.clone();
             let schedule_label = Main;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub fn schedule_graph_dot(
     label: impl ScheduleLabel,
     settings: &schedule_graph::Settings,
 ) -> String {
-    app.world
+    app.world_mut()
         .resource_scope::<Schedules, _>(|world, mut schedules| {
             let ignored_ambiguities = schedules.ignored_scheduling_ambiguities.clone();
 
@@ -61,8 +61,8 @@ pub fn render_graph_dot(app: &App, settings: &render_graph::Settings) -> String 
 
     let render_app = app
         .get_sub_app(bevy_render::RenderApp)
-        .unwrap_or_else(|_| panic!("no render app"));
-    let render_graph = render_app.world.get_resource::<RenderGraph>().unwrap();
+        .unwrap_or_else(|| panic!("no render app"));
+    let render_graph = render_app.world().get_resource::<RenderGraph>().unwrap();
 
     render_graph::render_graph_dot(render_graph, &settings)
 }

--- a/src/render_graph/mod.rs
+++ b/src/render_graph/mod.rs
@@ -1,6 +1,6 @@
 pub mod settings;
 
-use bevy_utils::intern::Interned;
+use bevy_ecs::intern::Interned;
 pub use settings::Settings;
 
 use self::iter_utils::sorted;

--- a/src/schedule_graph/settings.rs
+++ b/src/schedule_graph/settings.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 
+use bevy_color::{Color, Hsla};
 use bevy_ecs::{component::ComponentId, system::System, world::World};
-use bevy_render::color::Color;
 
 use super::system_style::{color_to_hex, system_to_style, SystemStyle};
 
@@ -221,7 +221,12 @@ impl Settings {
         let style = (self.system_style)(system);
 
         // Check if bg is dark
-        let [h, s, l, _] = style.bg_color.as_hsla_f32();
+        let Hsla {
+            hue: h,
+            saturation: s,
+            lightness: l,
+            alpha: _,
+        } = Hsla::from(style.bg_color);
         // TODO Fix following: https://ux.stackexchange.com/q/107318
         let is_dark = l < 0.6;
 

--- a/src/schedule_graph/system_style.rs
+++ b/src/schedule_graph/system_style.rs
@@ -1,8 +1,8 @@
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
 
+use bevy_color::{Color, Srgba};
 use bevy_ecs::system::System;
-use bevy_render::color::Color;
 use bevy_utils::HashMap;
 
 static CRATE_COLORS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
@@ -47,9 +47,9 @@ pub struct SystemStyle {
 pub fn color_to_hex(color: Color) -> String {
     format!(
         "#{:0>2x}{:0>2x}{:0>2x}",
-        (color.r() * 255.0) as u8,
-        (color.g() * 255.0) as u8,
-        (color.b() * 255.0) as u8,
+        (color.to_srgba().red * 255.0) as u8,
+        (color.to_srgba().green * 255.0) as u8,
+        (color.to_srgba().blue * 255.0) as u8,
     )
 }
 
@@ -64,17 +64,18 @@ pub fn system_to_style(system: &dyn System<In = (), Out = ()>) -> SystemStyle {
 
     if is_apply_system_buffers {
         SystemStyle {
-            bg_color: Color::hex("E70000").unwrap(),
-            text_color: Some(Color::hex("ffffff").unwrap()),
-            border_color: Some(Color::hex("5A0000").unwrap()),
+            bg_color: Srgba::hex("E70000").unwrap().into(),
+            text_color: Some(Srgba::hex("ffffff").unwrap().into()),
+            border_color: Some(Srgba::hex("5A0000").unwrap().into()),
             border_width: 2.0,
         }
     } else {
         let bg_color = crate_name
             .and_then(|n| CRATE_COLORS.get(n))
-            .map(Color::hex)
-            .unwrap_or(Color::hex("eff1f3"))
-            .unwrap();
+            .map(Srgba::hex)
+            .unwrap_or(Srgba::hex("eff1f3"))
+            .unwrap()
+            .into();
 
         SystemStyle {
             bg_color,


### PR DESCRIPTION
I'm not sure how to fix the "generate_docs" examples, which [swaps out and in the `App::world`](https://github.com/Vrixyz/bevy_mod_debugdump/blob/6618fed0843a38abcd9b95d4c9c542acb237ebc6/examples/generate_docs.rs#L159), which is now behind getter/setters.

