### PR TITLE
Remove height=0 from invisible nodes.

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -122,7 +122,6 @@ impl DotGraph {
             &[
                 ("style", "invis"),
                 ("label", ""),
-                ("height", "0"),
                 ("shape", "point"),
             ],
         );


### PR DESCRIPTION
Invisible nodes are already invisible. A height of 0 can cause warnings in some versions of GraphViz (e.g., 12.0.0).

This actually fixed a lot of issues:

Before: ![image](https://github.com/user-attachments/assets/9f4b4183-6f53-46c2-90e2-49c36fda5b9e)
After: ![image](https://github.com/user-attachments/assets/0abeab37-366d-4537-9b9d-d4acb1b23717)

Before: ![image](https://github.com/user-attachments/assets/e4275f39-3531-4004-9697-c0378eae3e3a)
After: ![image](https://github.com/user-attachments/assets/f991e044-a83c-4d79-a190-18cd6a65ad4c)

Fixes #44.