### PR TITLE
Replace the runner when exiting the app through CommandLineArgs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,14 +189,10 @@ impl bevy_app::Plugin for CommandLineArgs {
         };
 
         if exit {
-            // TODO: It would be nice if we could exit before the window
-            // opens, but I don't see how.
-            app.add_systems(
-                bevy_app::First,
-                |mut app_exit_events: bevy_ecs::event::EventWriter<bevy_app::AppExit>| {
-                    app_exit_events.send(bevy_app::AppExit::Success);
-                },
-            );
+            // Set the runner to nothing, which will immediately quit the app.
+            app.set_runner(|_: App| {
+                bevy_app::AppExit::Success
+            });
         }
     }
 }


### PR DESCRIPTION
Previously, sending an AppExit event would result in the window opening up (which can be annoying). Now, by replacing the runner, Bevy doesn't start anything up or do an update cycle.

With #42, there is even less likely a situation where the runner is replaced (by another plugin) making this more robust.