### PR TITLE
Call std::process::exit directly from CommandLineArgs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,14 +189,7 @@ impl bevy_app::Plugin for CommandLineArgs {
         };
 
         if exit {
-            // TODO: It would be nice if we could exit before the window
-            // opens, but I don't see how.
-            app.add_systems(
-                bevy_app::First,
-                |mut app_exit_events: bevy_ecs::event::EventWriter<bevy_app::AppExit>| {
-                    app_exit_events.send(bevy_app::AppExit::Success);
-                },
-            );
+            std::process::exit(0);
         }
     }
 }


### PR DESCRIPTION
Previously, sending an AppExit event would result in the window opening up (which can be annoying). Now, by just calling std::process:exit, we just quit right on the spot.

Note we already std::process::exit in the help flag, so this isn't much different.