### PR TITLE
Add System Set Filters

### DIFF
--- a/examples/print_schedule_graph_advanced_filters.rs
+++ b/examples/print_schedule_graph_advanced_filters.rs
@@ -1,0 +1,38 @@
+use bevy::log::LogPlugin;
+use bevy::prelude::*;
+use bevy_app::DynEq;
+use bevy_mod_debugdump::schedule_graph::Settings;
+
+fn special_system_a() {}
+fn special_system_b() {}
+fn regular_system_c() {}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SystemSet)]
+enum ExampleSystemSet {
+    Special,
+    Regular,
+}
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>())
+        .configure_sets(
+            Update,
+            (ExampleSystemSet::Special, ExampleSystemSet::Regular),
+        )
+        .add_systems(
+            Update,
+            (special_system_a, special_system_b, regular_system_c).chain(),
+        );
+
+    let settings = Settings::default()
+        .filter_in_crate("print_schedule_graph_advanced_filters")
+        .with_system_filter(|system| system.name().contains("special"))
+        .with_system_set_filter(|system_set| {
+            system_set
+                .as_dyn_eq()
+                .dyn_eq(ExampleSystemSet::Special.as_dyn_eq())
+        });
+    let dot = bevy_mod_debugdump::schedule_graph_dot(&mut app, Update, &settings);
+    println!("{dot}");
+}

--- a/src/schedule_graph/mod.rs
+++ b/src/schedule_graph/mod.rs
@@ -493,9 +493,11 @@ fn included_systems_sets(graph: &ScheduleGraph, settings: &Settings) -> HashSet<
     let hierarchy = graph.hierarchy().graph();
 
     let root_sets = hierarchy.nodes().filter(|&node| {
+        if !node.is_set() {
+            return false;
+        }
         let system_set = graph.set_at(node);
-        node.is_set()
-            && system_set.system_type().is_none()
+        system_set.system_type().is_none()
             && system_set_filter(system_set)
             && hierarchy
                 .neighbors_directed(node, Direction::Incoming)

--- a/src/schedule_graph/settings.rs
+++ b/src/schedule_graph/settings.rs
@@ -183,6 +183,7 @@ pub struct Settings {
 
     /// When set to `Some`, will only include systems matching the predicate, and their ancestor sets
     pub include_system: Option<SystemMapperFn<bool>>,
+    pub include_system_set: Option<SystemSetMapperFn<bool>>,
     pub collapse_single_system_sets: bool,
 
     pub ambiguity_enable: bool,
@@ -301,6 +302,7 @@ impl Default for Settings {
             system_style: Box::new(system_to_style),
 
             include_system: None,
+            include_system_set: None,
             collapse_single_system_sets: false,
 
             ambiguity_enable: true,


### PR DESCRIPTION
This is a PR to address Issue #26 

I've added a new `include_system_set` member to `Settings`.
Inside `included_systems_sets`, I'm checking this mapper to skip any unwanted system sets.

I think the logic inside `included_systems_sets` could use a bit of clean up, but it seems to be working correctly based on my testing.

I've included `print_schedule_graph_advanced_filters.rs` as an example/test.