### PR TITLE
Bug: too noisy graph displayed

### DIFF
--- a/examples/schedule_graph_child_set.rs
+++ b/examples/schedule_graph_child_set.rs
@@ -1,0 +1,35 @@
+use bevy::{log::LogPlugin, prelude::*};
+
+/// A set for rapier's copying bevy_rapier's Bevy components back into rapier.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+pub struct SystemSet1;
+
+/// A set for rapier's copying bevy_rapier's Bevy components back into rapier.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+pub struct SystemSet2;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+    app.add_systems(
+        Update,
+        (
+            system1_no_set,
+            (
+                (
+                    system_in_child_set1.in_set(SystemSet1),
+                    system_in_child_set1.in_set(SystemSet1),
+                ),
+                system_in_child_set2.in_set(SystemSet2),
+            )
+                .chain(),
+        )
+            .chain(),
+    );
+    bevy_mod_debugdump::print_schedule_graph(&mut app, Update);
+}
+
+fn system_in_child_set1() {}
+
+fn system_in_child_set2() {}
+fn system1_no_set() {}


### PR DESCRIPTION
I'm not sure if the bug is originating from this crate or bevy, but it seems weird that `system_no_set` is linked to `system_in_child_set2` (green arrow should not exist).

![Screenshot from 2024-09-11 11-13-21](https://github.com/user-attachments/assets/7472bd7c-984f-4716-94db-67e2014b7988)

## Real project example

- From https://github.com/dimforge/bevy_rapier/pull/585

- Current output from bevy_mod_debugdump:

![dump_with_transitive](https://github.com/user-attachments/assets/7fc3f36f-a2ca-4ec0-ade3-f0e873d934b0)

- Expected output (obtained with this PR):

![dump_no_transitive](https://github.com/user-attachments/assets/45dbcea9-b1c3-4ef8-86e7-5b7e033f5bea)