### PR TITLE
Upgrade to Bevy 0.15.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ default = ["render_graph"]
 render_graph = []
 
 [dependencies]
-bevy_ecs = { version = "0.14.0-rc.3" }
-bevy_app = { version = "0.14.0-rc.3" }
-bevy_utils = { version = "0.14.0-rc.3" }
-bevy_render = { version = "0.14.0-rc.3" }
-bevy_color = { version = "0.14.0-rc.3" }
+bevy_ecs = { version = "0.15.0-rc.1" }
+bevy_app = { version = "0.15.0-rc.1" }
+bevy_utils = { version = "0.15.0-rc.1" }
+bevy_render = { version = "0.15.0-rc.1" }
+bevy_color = { version = "0.15.0-rc.1" }
 pretty-type-name = "1.0"
 petgraph = "0.6"
 once_cell = "1.17"
 lexopt = "0.3.0"
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.3" }
+bevy = { version = "0.15.0-rc.1" }
 
 [[example]]
 name = "print_render_graph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_debugdump"
-version = "0.12.0-rc.1"
+version = "0.12.0"
 repository = "https://github.com/jakobhellermann/bevy_mod_debugdump"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -15,18 +15,18 @@ default = ["render_graph"]
 render_graph = []
 
 [dependencies]
-bevy_ecs = { version = "0.15.0-rc.1" }
-bevy_app = { version = "0.15.0-rc.1" }
-bevy_utils = { version = "0.15.0-rc.1" }
-bevy_render = { version = "0.15.0-rc.1" }
-bevy_color = { version = "0.15.0-rc.1" }
+bevy_ecs = { version = "0.15.0" }
+bevy_app = { version = "0.15.0" }
+bevy_utils = { version = "0.15.0" }
+bevy_render = { version = "0.15.0" }
+bevy_color = { version = "0.15.0" }
 pretty-type-name = "1.0"
 petgraph = "0.6"
 once_cell = "1.17"
 lexopt = "0.3.0"
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.1" }
+bevy = { version = "0.15.0" }
 
 [[example]]
 name = "print_render_graph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_debugdump"
-version = "0.11.1"
+version = "0.12.0-rc.1"
 repository = "https://github.com/jakobhellermann/bevy_mod_debugdump"
 readme = "README.md"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
There's nothing to do here except bump version numbers.

After merging, we need to `cargo publish` this.

I ran the tests, and ran the `print_render_graph` example and everything seems to be working.