### PR TITLE
Fix render dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ exclude = ["docs/*"]
 
 [features]
 default = ["render_graph"]
-render_graph = []
+render_graph = ["dep:bevy_render"]
 
 [dependencies]
 bevy_ecs = { version = "0.15.0" }
 bevy_app = { version = "0.15.0" }
 bevy_utils = { version = "0.15.0" }
-bevy_render = { version = "0.15.0" }
+bevy_render = { version = "0.15.0", optional = true }
 bevy_color = { version = "0.15.0" }
 pretty-type-name = "1.0"
 petgraph = "0.6"
@@ -27,6 +27,10 @@ lexopt = "0.3.0"
 
 [dev-dependencies]
 bevy = { version = "0.15.0" }
+
+[[example]]
+name = "generate_docs"
+required-features = ["render_graph"]
 
 [[example]]
 name = "print_render_graph"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,9 @@ use bevy_ecs::{intern::Interned, schedule::ScheduleLabel, schedule::Schedules};
 use bevy_utils::tracing::{error, info};
 use std::io::Write;
 
-use crate::{render_graph, render_graph_dot, schedule_graph, schedule_graph_dot};
+#[cfg(feature = "render_graph")]
+use crate::{render_graph, render_graph_dot};
+use crate::{schedule_graph, schedule_graph_dot};
 
 /// Check the command line for arguments relevant to this crate.
 ///
@@ -157,12 +159,18 @@ fn execute_cli(app: &mut App) -> Result<Args> {
             args.exit = false;
             Ok(args)
         }
+        #[cfg(feature = "render_graph")]
         ArgsCommand::DumpRender => {
             let settings = render_graph::Settings::default();
             write(&render_graph_dot(app, &settings))?;
 
             Ok(args)
         }
+        #[cfg(not(feature = "render_graph"))]
+        ArgsCommand::DumpRender => Err(
+            "cannot dump renderer, consider enabling the feature `bevy_mod_debugdump/render_graph"
+                .into(),
+        ),
         ArgsCommand::DumpSchedule { schedule } => {
             let schedule = find_schedule(&app, schedule)?;
 


### PR DESCRIPTION
There was some work done to make showing the render graph an optional feature, but it was incomplete. It caused compiler errors and it still included a dependency on `bevy_render`.