### PR TITLE
Update bevy to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,19 @@ default = ["render_graph"]
 render_graph = ["dep:bevy_render"]
 
 [dependencies]
-bevy_ecs = { version = "0.15.0" }
-bevy_app = { version = "0.15.0" }
-bevy_utils = { version = "0.15.0" }
-bevy_render = { version = "0.15.0", optional = true }
-bevy_color = { version = "0.15.0" }
+bevy_app = { version = "0.16.0-rc.2" }
+bevy_color = { version = "0.16.0-rc.2" }
+bevy_ecs = { version = "0.16.0-rc.2" }
+bevy_log = { version = "0.16.0-rc.2" }
+bevy_platform_support = { version = "0.16.0-rc.2" }
+bevy_render = { version = "0.16.0-rc.2", optional = true }
+bevy_utils = { version = "0.16.0-rc.2" }
 pretty-type-name = "1.0"
-petgraph = "0.6"
+petgraph = "0.7"
 lexopt = "0.3.0"
 
 [dev-dependencies]
-bevy = { version = "0.15.0" }
+bevy = { version = "0.16.0-rc.2" }
 
 [[example]]
 name = "generate_docs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ bevy_platform_support = { version = "0.16.0-rc.2" }
 bevy_render = { version = "0.16.0-rc.2", optional = true }
 bevy_utils = { version = "0.16.0-rc.2" }
 pretty-type-name = "1.0"
-petgraph = "0.7"
 lexopt = "0.3.0"
 
 [dev-dependencies]

--- a/examples/generate_docs.rs
+++ b/examples/generate_docs.rs
@@ -51,12 +51,12 @@ fn main() -> Result<(), std::io::Error> {
             for (label, schedule) in schedules.iter() {
                 let dot_light = bevy_mod_debugdump::schedule_graph::schedule_graph_dot(
                     schedule,
-                    &world,
+                    world,
                     &settings_light,
                 );
                 let dot_dark = bevy_mod_debugdump::schedule_graph::schedule_graph_dot(
                     schedule,
-                    &world,
+                    world,
                     &settings_dark,
                 );
 
@@ -107,12 +107,12 @@ fn main() -> Result<(), std::io::Error> {
 
                     let dot_light = bevy_mod_debugdump::schedule_graph::schedule_graph_dot(
                         schedule,
-                        &world,
+                        world,
                         &settings_light,
                     );
                     let dot_dark = bevy_mod_debugdump::schedule_graph::schedule_graph_dot(
                         schedule,
-                        &world,
+                        world,
                         &settings_dark,
                     );
 
@@ -144,7 +144,7 @@ fn initialize_schedules(
     world: &mut World,
 ) -> Result<(), std::io::Error> {
     let ignored_ambiguities = schedules.ignored_scheduling_ambiguities.clone();
-    Ok(for (_, schedule) in schedules.iter_mut() {
+    for (_, schedule) in schedules.iter_mut() {
         // for access info
         schedule.graph_mut().initialize(world);
         // for `conflicting_systems`
@@ -152,7 +152,8 @@ fn initialize_schedules(
             .graph_mut()
             .build_schedule(world, ScheduleDebugGroup.intern(), &ignored_ambiguities)
             .unwrap();
-    })
+    }
+    Ok(())
 }
 
 fn with_main_world_in_render_app<T>(app: &mut App, f: impl Fn(&mut SubApp) -> T) -> T {

--- a/examples/generate_docs.rs
+++ b/examples/generate_docs.rs
@@ -11,7 +11,7 @@ use bevy_ecs::schedule::ScheduleLabel;
 use bevy_mod_debugdump::schedule_graph::{settings::Style, Settings};
 use bevy_render::{
     batching::{
-        gpu_preprocessing::{BatchedInstanceBuffers, IndirectParametersBuffer},
+        gpu_preprocessing::{BatchedInstanceBuffers, IndirectParametersBuffers},
         no_gpu_preprocessing::BatchedInstanceBuffer,
     },
     render_asset::RenderAssetBytesPerFrame,
@@ -81,17 +81,13 @@ fn main() -> Result<(), std::io::Error> {
 
                     schedule
                         .graph_mut()
-                        .build_schedule(
-                            world.components(),
-                            ScheduleDebugGroup.intern(),
-                            &ignored_ambiguities,
-                        )
+                        .build_schedule(world, ScheduleDebugGroup.intern(), &ignored_ambiguities)
                         .unwrap();
 
                     let ignore_ambiguities = &[
                         TypeId::of::<bevy_render::MainWorld>(),
                         TypeId::of::<bevy_render::texture::TextureCache>(),
-                        TypeId::of::<IndirectParametersBuffer>(),
+                        TypeId::of::<IndirectParametersBuffers>(),
                         TypeId::of::<BatchedInstanceBuffers<MeshUniform, MeshInputUniform>>(),
                         TypeId::of::<BatchedInstanceBuffer<MeshUniform>>(),
                         TypeId::of::<BatchedInstanceBuffer<Mesh2dUniform>>(),
@@ -154,11 +150,7 @@ fn initialize_schedules(
         // for `conflicting_systems`
         schedule
             .graph_mut()
-            .build_schedule(
-                world.components(),
-                ScheduleDebugGroup.intern(),
-                &ignored_ambiguities,
-            )
+            .build_schedule(world, ScheduleDebugGroup.intern(), &ignored_ambiguities)
             .unwrap();
     })
 }

--- a/examples/schedule_graph_compare.rs
+++ b/examples/schedule_graph_compare.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), std::io::Error> {
                 let mut settings = Settings::default();
                 settings.style.edge_style = edge_style;
                 let dot = bevy_mod_debugdump::schedule_graph::schedule_graph_dot(
-                    schedule, &world, &settings,
+                    schedule, world, &settings,
                 );
 
                 std::fs::write(

--- a/examples/schedule_graph_compare.rs
+++ b/examples/schedule_graph_compare.rs
@@ -25,11 +25,7 @@ fn main() -> Result<(), std::io::Error> {
             // for `conflicting_systems`
             schedule
                 .graph_mut()
-                .build_schedule(
-                    world.components(),
-                    ScheduleDebugGroup.intern(),
-                    &ignored_ambiguities,
-                )
+                .build_schedule(world, ScheduleDebugGroup.intern(), &ignored_ambiguities)
                 .unwrap();
 
             for edge_style in [

--- a/examples/schedule_graph_testing.rs
+++ b/examples/schedule_graph_testing.rs
@@ -1,12 +1,13 @@
 #![allow(unused)]
 use std::{collections::BTreeSet, path::PathBuf};
 
-use bevy::{prelude::*, render::RenderApp, utils::HashSet};
+use bevy::{prelude::*, render::RenderApp};
 use bevy_ecs::{
     component::ComponentId,
     schedule::{NodeId, ScheduleLabel},
 };
 use bevy_mod_debugdump::schedule_graph::Settings;
+use bevy_platform_support::collections::hash_set::HashSet;
 
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 struct ScheduleDebugGroup;
@@ -39,11 +40,7 @@ fn main() -> Result<(), std::io::Error> {
             schedule.graph_mut().initialize(world);
             schedule
                 .graph_mut()
-                .build_schedule(
-                    world.components(),
-                    ScheduleDebugGroup.intern(),
-                    &ignored_ambiguities,
-                )
+                .build_schedule(world, ScheduleDebugGroup.intern(), &ignored_ambiguities)
                 .unwrap();
 
             let settings = Settings {
@@ -96,13 +93,13 @@ fn print_schedule(schedule: &Schedule, schedule_label: &dyn ScheduleLabel) {
 
     println!("- HIERARCHY");
     let hierarchy = graph.hierarchy();
-    for (from, to, ()) in hierarchy.graph().all_edges() {
+    for (from, to) in hierarchy.graph().all_edges() {
         println!("  - {} -> {}", name_of_node(from), name_of_node(to));
     }
 
     println!("- DEPENDENCY");
     let hierarchy = graph.dependency();
-    for (from, to, ()) in hierarchy.graph().all_edges() {
+    for (from, to) in hierarchy.graph().all_edges() {
         println!("  - {} -> {}", name_of_node(from), name_of_node(to));
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use std::{fs::File, path::PathBuf};
 
 use bevy_app::App;
 use bevy_ecs::{intern::Interned, schedule::ScheduleLabel, schedule::Schedules};
-use bevy_utils::tracing::{error, info};
+use bevy_log::{error, info};
 use std::io::Write;
 
 #[cfg(feature = "render_graph")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,7 @@ impl bevy_app::Plugin for CommandLineArgs {
             app.add_systems(
                 bevy_app::First,
                 |mut app_exit_events: bevy_ecs::event::EventWriter<bevy_app::AppExit>| {
-                    app_exit_events.send(bevy_app::AppExit::Success);
+                    app_exit_events.write(bevy_app::AppExit::Success);
                 },
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub fn schedule_graph_dot(
                 .unwrap();
             schedule.graph_mut().initialize(world);
             let _ = schedule.graph_mut().build_schedule(
-                world.components(),
+                world,
                 ScheduleDebugGroup.intern(),
                 &ignored_ambiguities,
             );

--- a/src/schedule_graph/mod.rs
+++ b/src/schedule_graph/mod.rs
@@ -106,10 +106,10 @@ pub fn schedule_graph_dot(schedule: &Schedule, world: &World, settings: &Setting
 
             let children_sets_empty = sets_in_single_set
                 .get(&set_id)
-                .map_or(true, |vec| vec.is_empty());
+                .is_none_or(|vec| vec.is_empty());
             let children_sets_in_multiple_empty = systems_in_multiple_sets
                 .get(&Some(set_id))
-                .map_or(true, |vec| vec.is_empty());
+                .is_none_or(|vec| vec.is_empty());
 
             if children_in_multiple.is_empty()
                 && children.len() <= 1

--- a/src/schedule_graph/mod.rs
+++ b/src/schedule_graph/mod.rs
@@ -1,7 +1,8 @@
 pub mod settings;
 pub mod system_style;
 
-use bevy_utils::{HashMap, HashSet};
+use bevy_platform_support::collections::hash_map::HashMap;
+use bevy_platform_support::collections::hash_set::HashSet;
 pub use settings::Settings;
 
 use std::{any::TypeId, borrow::Cow, collections::VecDeque, fmt::Write, sync::atomic::AtomicUsize};
@@ -12,7 +13,7 @@ use bevy_ecs::{
     system::System,
     world::World,
 };
-use petgraph::{prelude::DiGraphMap, Direction};
+use petgraph::{prelude::*, Direction};
 
 /// Formats the schedule into a dot graph.
 pub fn schedule_graph_dot(schedule: &Schedule, world: &World, settings: &Settings) -> String {
@@ -27,8 +28,8 @@ pub fn schedule_graph_dot(schedule: &Schedule, world: &World, settings: &Setting
 
     // collect sets and systems
     let mut systems_freestanding = Vec::new();
-    let mut systems_in_single_set = HashMap::<NodeId, Vec<_>>::new();
-    let mut systems_in_multiple_sets = bevy_utils::HashMap::<Option<NodeId>, Vec<_>>::new();
+    let mut systems_in_single_set = HashMap::<NodeId, Vec<_>>::default();
+    let mut systems_in_multiple_sets = HashMap::<Option<NodeId>, Vec<_>>::default();
 
     for (system_id, system, _condition) in graph
         .systems()
@@ -56,8 +57,8 @@ pub fn schedule_graph_dot(schedule: &Schedule, world: &World, settings: &Setting
     }
 
     let mut sets_freestanding = Vec::new();
-    let mut sets_in_single_set = HashMap::<NodeId, Vec<_>>::new();
-    let mut sets_in_multiple_sets = bevy_utils::HashMap::<Option<NodeId>, Vec<_>>::new();
+    let mut sets_in_single_set = HashMap::<NodeId, Vec<_>>::default();
+    let mut sets_in_multiple_sets = HashMap::<Option<NodeId>, Vec<_>>::default();
 
     let mut collapsed_sets = HashSet::new();
     let mut collapsed_set_children = HashMap::new();

--- a/src/schedule_graph/settings.rs
+++ b/src/schedule_graph/settings.rs
@@ -1,12 +1,7 @@
 use std::any::TypeId;
 
 use bevy_color::{Color, Hsla};
-use bevy_ecs::{
-    component::ComponentId,
-    schedule::SystemSet,
-    system::{ScheduleSystem, System},
-    world::World,
-};
+use bevy_ecs::{component::ComponentId, schedule::SystemSet, system::ScheduleSystem, world::World};
 
 use super::system_style::{color_to_hex, system_to_style, SystemStyle};
 

--- a/src/schedule_graph/settings.rs
+++ b/src/schedule_graph/settings.rs
@@ -1,7 +1,12 @@
 use std::any::TypeId;
 
 use bevy_color::{Color, Hsla};
-use bevy_ecs::{component::ComponentId, schedule::SystemSet, system::System, world::World};
+use bevy_ecs::{
+    component::ComponentId,
+    schedule::SystemSet,
+    system::{ScheduleSystem, System},
+    world::World,
+};
 
 use super::system_style::{color_to_hex, system_to_style, SystemStyle};
 
@@ -157,12 +162,7 @@ impl Default for Style {
     }
 }
 
-type IncludeAmbiguityFn = dyn Fn(
-    &dyn System<In = (), Out = ()>,
-    &dyn System<In = (), Out = ()>,
-    &[ComponentId],
-    &World,
-) -> bool;
+type IncludeAmbiguityFn = dyn Fn(&ScheduleSystem, &ScheduleSystem, &[ComponentId], &World) -> bool;
 
 pub struct NodeStyle {
     pub bg_color: String,
@@ -172,7 +172,7 @@ pub struct NodeStyle {
 }
 
 // Function that maps `System` to `T`
-type SystemMapperFn<T> = Box<dyn Fn(&dyn System<In = (), Out = ()>) -> T>;
+type SystemMapperFn<T> = Box<dyn Fn(&ScheduleSystem) -> T>;
 
 // Function that maps `SystemSet` to `T`
 type SystemSetMapperFn<T> = Box<dyn Fn(&dyn SystemSet) -> T>;
@@ -222,7 +222,7 @@ impl Settings {
         self
     }
 
-    pub fn get_system_style(&self, system: &dyn System<In = (), Out = ()>) -> NodeStyle {
+    pub fn get_system_style(&self, system: &ScheduleSystem) -> NodeStyle {
         let style = (self.system_style)(system);
 
         // Check if bg is dark
@@ -314,11 +314,11 @@ impl Default for Settings {
     }
 }
 
-pub fn pretty_system_name(system: &dyn System<In = (), Out = ()>) -> String {
+pub fn pretty_system_name(system: &ScheduleSystem) -> String {
     pretty_type_name::pretty_type_name_str(&system.name())
 }
 
-pub fn full_system_name(system: &dyn System<In = (), Out = ()>) -> String {
+pub fn full_system_name(system: &ScheduleSystem) -> String {
     system.name().into()
 }
 

--- a/src/schedule_graph/system_style.rs
+++ b/src/schedule_graph/system_style.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use bevy_color::{Color, Srgba};
-use bevy_ecs::system::{ScheduleSystem, System};
+use bevy_ecs::system::ScheduleSystem;
 use bevy_platform_support::collections::hash_map::HashMap;
 
 static CRATE_COLORS: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {

--- a/src/schedule_graph/system_style.rs
+++ b/src/schedule_graph/system_style.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use bevy_color::{Color, Srgba};
-use bevy_ecs::system::System;
+use bevy_ecs::system::{ScheduleSystem, System};
 use bevy_platform_support::collections::hash_map::HashMap;
 
 static CRATE_COLORS: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
@@ -53,7 +53,7 @@ pub fn color_to_hex(color: Color) -> String {
     )
 }
 
-pub fn system_to_style(system: &dyn System<In = (), Out = ()>) -> SystemStyle {
+pub fn system_to_style(system: &ScheduleSystem) -> SystemStyle {
     let name = system.name();
     let pretty_name: Cow<str> = pretty_type_name::pretty_type_name_str(&name).into();
     let is_apply_system_buffers = pretty_name == "apply_system_buffers";

--- a/src/schedule_graph/system_style.rs
+++ b/src/schedule_graph/system_style.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use bevy_color::{Color, Srgba};
 use bevy_ecs::system::System;
-use bevy_utils::HashMap;
+use bevy_platform_support::collections::hash_map::HashMap;
 
 static CRATE_COLORS: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
     [


### PR DESCRIPTION
- Updated bevy version to `0.16.0-rc.2`.
- Migrated code to be compatible with the new version.

